### PR TITLE
deepseek v3.2 support

### DIFF
--- a/include/minja/chat-template.hpp
+++ b/include/minja/chat-template.hpp
@@ -197,7 +197,7 @@ class chat_template {
                 || contains(out_str, "\"argument_needle\":")
                 || contains(out_str, "'argument_needle':")
                 || contains(out_str, ">argument_needle<")
-                || contains(out_str, "<parameter name=\"argument_needle\">");
+                || contains(out_str, "=\"argument_needle\"");
         };
 
         // Note: the arguments are rendered in both cases, but may be double-escaped, which we don't want.


### PR DESCRIPTION
Deepseek V3.2 uses a new tool-call format like this:
```
<｜DSML｜function_calls>
<｜DSML｜invoke name="get_datetime">
<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
</｜DSML｜invoke>
</｜DSML｜function_calls>
```
```
<｜DSML｜function_calls>
<｜DSML｜invoke name="search">
<｜DSML｜parameter name="query" string="true">search agent benchmark 2024</｜DSML｜parameter>
<｜DSML｜parameter name="topn" string="false">10</｜DSML｜parameter>
<｜DSML｜parameter name="source" string="true">web</｜DSML｜parameter>
</｜DSML｜invoke>
<｜DSML｜invoke name="search">
<｜DSML｜parameter name="query" string="true">搜索智能体 基准测试</｜DSML｜parameter>
<｜DSML｜parameter name="topn" string="false">10</｜DSML｜parameter>
<｜DSML｜parameter name="source" string="true">web</｜DSML｜parameter>
</｜DSML｜invoke>
</｜DSML｜function_calls>
```

Maybe we should update the polyfill detection code for this.